### PR TITLE
Switch to .NET 4(.5)

### DIFF
--- a/app.config
+++ b/app.config
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v2.0.50727"/></startup></configuration>
+<startup><supportedRuntime version="v4.0.30319"/></startup></configuration>
 


### PR DESCRIPTION
For more modern support and Windows on ARM processors. This pull request enables an IceChat build to run unmodified on RT 8.1(tested with a compile done on my RT 8.1 device, as I have MSBuild there)
